### PR TITLE
Query params to profile send amount & address

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -22,6 +22,8 @@ var localPowWorking = false;
 var pow_workers;
 
 var RESOLVE_FORKS_BLOCK_BATCH_SIZE = 20;
+var RAI_TO_RAW = "000000000000000000000000";
+var MILLION = 1000000;
 
 $(document).ready(function(){
 	
@@ -834,7 +836,19 @@ $(document).ready(function(){
 			$('#button_2fa').removeClass('btn-danger');
 		}
 	}
-	
+
+  function rawToMrai(value) {
+    if (typeof value !== 'string') {
+      throw 'rawToMrai expects a string';
+    }
+
+    const amountRaw = bigInt(value);
+    const amountRai = amountRaw.divide("1000000000000000000000000");
+    const amountMrai = parseFloat(amountRai / MILLION);
+
+    return amountMrai;
+  }
+
 	function goToWallet()
 	{
 		// stop live txs script
@@ -874,12 +888,40 @@ $(document).ready(function(){
 				lastAction = Date.now() / 1000;
 			});
 			
-			window.history.pushState("home", "RaiWallet - Home", "/home");
-			document.title = 'RaiWallet - Home';
-			
-			setTimeout(function(){
-				$('.landing').fadeOut(500, function(){$('.landing').remove(); $('.wallet-wrapper').fadeIn();});
-			}, 1000);
+      const params = (new URL(location)).searchParams;
+      let encoded_address = params.get('encoded_address');
+      let amountMrai = params.get('amount') ? rawToMrai(params.get('amount')) : undefined;
+
+      window.history.pushState("home", "RaiWallet - Home", "/home");
+      document.title = 'RaiWallet - Home';
+      
+      setTimeout(function(){
+        $('.landing').fadeOut(500, function(){
+          $('.landing').remove();
+          $('.wallet-wrapper').fadeIn();
+        });
+
+        if (encoded_address || amountMrai) {
+          $("#send-modal").on('shown.bs.modal', function (e) {
+            if (encoded_address && parseXRBaccount(encoded_address)) {
+              $("#to").val(encoded_address);
+            }
+
+            if (amountMrai && isFinite(amountMrai)) {
+              $("#samount").val(amountMrai);
+            }
+
+            // Remove the event
+            $("#send-modal").off('shown.bs.modal');
+
+            // Set to undefined, incase this method is called again
+            amountMrai = undefined;
+            encoded_address = undefined;
+          });
+
+          $("#send-modal").modal();
+        }
+      }, 1000);
 		});
 
 	}


### PR DESCRIPTION
**Testing**

1. Set encoded_address and amount as a query parameters
2. Login / Register
3. Send modal should open, with values from above already set.

**Notes**
Amount is in raw to keep consistent with https://github.com/clemahieu/raiblocks/wiki/URI-and-QR-Code-Standard